### PR TITLE
Feature/css selector parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+
+- Minimal typescript version is now 4.2 due to the dependency to [typed-query-selector](https://github.com/g-plane/typed-query-selector).
+
+### Changed
+
+- Added type-level CSS selector parsing to all functions that query the DOM with given selectors ([PR](https://github.com/JJWesterkamp/lambda-dom/pull/5))
+
 ## [1.3.1] (2021-04-05)
 
 ### Fixed
@@ -19,22 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - function `showUsing`
 - type `StylableElement`
 - type `CssdisplayValue`
-  
+
 ### Changed
 
 - Changed `string | null` types for `style.display` values in CSS display functions to `CssDisplayValue` to
   provide an autocompletion list of the most commonly used display values.
-  
+
   **Affects:**
   - `display`
   - `displayIf`
   - `displayUsing` (new)
-    
-  
-- Loosened `HTMLElement` type constraints to `ElementCSSInlineStyle` (aliased as `StylableElement`) for 
-  CSS style related functions. This allows for usage of these functions with other supported elements as well, 
+
+
+- Loosened `HTMLElement` type constraints to `ElementCSSInlineStyle` (aliased as `StylableElement`) for
+  CSS style related functions. This allows for usage of these functions with other supported elements as well,
   such as SVG elements.
-  
+
   **Affects:**
   - `display`
   - `show`
@@ -48,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Loosened `HTMLElement` type constraints to `HTMLOrSVGElement` for dataset functions to allow usage of these
   functions with SVG elements as well.
-  
+
   **Affects:**
   - `readDataset`
   - `writeDataset`

--- a/docs/index.html
+++ b/docs/index.html
@@ -2902,7 +2902,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">Css<wbr>Display<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;block&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;contents&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;flex&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;grid&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inherit&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;initial&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-block&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-flex&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-grid&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-table&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;list-item&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;none&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;run-in&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-caption&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-cell&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-column&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-column-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-footer-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-header-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-row&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-row-group&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/_types.ts#L7">_types.ts:7</a></li>
+						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/_types.ts#L7">_types.ts:7</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2920,7 +2920,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">Stylable<wbr>Element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ElementCSSInlineStyle</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/_types.ts#L41">_types.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/_types.ts#L41">_types.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2945,7 +2945,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/DOMReadyP.ts#L9">DOMReadyP.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/DOMReadyP.ts#L9">DOMReadyP.ts:9</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2970,7 +2970,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClasses.ts#L24">addClasses.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClasses.ts#L24">addClasses.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3038,7 +3038,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClassesForMS.ts#L18">addClassesForMS.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClassesForMS.ts#L18">addClassesForMS.ts:18</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3103,7 +3103,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClassesForNFrames.ts#L19">addClassesForNFrames.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClassesForNFrames.ts#L19">addClassesForNFrames.ts:19</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3168,7 +3168,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/deferFrames.ts#L28">deferFrames.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/deferFrames.ts#L28">deferFrames.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3239,7 +3239,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/deferFramesP.ts#L20">deferFramesP.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/deferFramesP.ts#L20">deferFramesP.ts:20</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3282,7 +3282,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/display.ts#L34">display.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/display.ts#L34">display.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3359,7 +3359,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/displayIf.ts#L28">displayIf.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/displayIf.ts#L28">displayIf.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3430,7 +3430,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/displayUsing.ts#L28">displayUsing.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/displayUsing.ts#L28">displayUsing.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3520,7 +3520,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/getMeta.ts#L42">getMeta.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/getMeta.ts#L42">getMeta.ts:42</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3565,7 +3565,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/getMeta.ts#L85">getMeta.ts:85</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/getMeta.ts#L85">getMeta.ts:85</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3649,7 +3649,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/hide.ts#L21">hide.ts:21</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/hide.ts#L21">hide.ts:21</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3693,7 +3693,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/onDOMReady.ts#L12">onDOMReady.ts:12</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/onDOMReady.ts#L12">onDOMReady.ts:12</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3743,7 +3743,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/onWindowLoad.ts#L12">onWindowLoad.ts:12</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/onWindowLoad.ts#L12">onWindowLoad.ts:12</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3787,33 +3787,32 @@ img {
 				<a name="queryall" class="tsd-anchor"></a>
 				<h3>query<wbr>All</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
-					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
-					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
+					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;S&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></li>
 					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;T&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L22">queryAll.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryAll.ts#L24">queryAll.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
 								<p>Calls <code>querySelectorAll</code> with given <code>selector</code> on given <code>scope</code>, or on <code>document</code> by default when the
-								scope is omitted. Returns an array containing the found elements.</p>
+									scope is omitted. Returns an array containing the found elements. Attempts to parse the given CSS selector
+								to determine the element type.</p>
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Recognizes keys of HTMLElementTagNameMap:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">anchors</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;a&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLAnchorElement[]</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into an element type.</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">headings</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;h2.large-heading, h3.medium-heading&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLHeadingElement[]</span>
 
-<span style="color: #C2C3C5">// Recognizes keys of SVGElementTagNameMap:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">paths</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;path&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// SVGPathElement[]</span>
+<span style="color: #C2C3C5">// Defaults to Element for unrecognised selectors:</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">components</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;custom-web-component&#039;</span><span style="color: #24292EFF">)              </span><span style="color: #C2C3C5">// Element[]</span>
 
-<span style="color: #C2C3C5">// Defaults to Element, or accepts an explicit type argument for the searched elements:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elements</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;.some-element&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// Element[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLButtonElement[]</span>
+<span style="color: #C2C3C5">// Accepts an explicit type argument for the searched elements:</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">components</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">MyComponent</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;custom-web-component&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// MyComponent[]</span>
 </code></pre>
 								</dd>
 							</dl>
@@ -3821,13 +3820,13 @@ img {
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
-								<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">HTMLElementTagNameMap</span></h4>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
 						<ul class="tsd-parameters">
 							<li>
-								<h5>selector: <span class="tsd-signature-type">K</span></h5>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
 								<div class="tsd-comment tsd-typography">
 									<p>The selector to match elements against.</p>
 								</div>
@@ -3839,35 +3838,12 @@ img {
 								</div>
 							</li>
 						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></h4>
 					</li>
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L23">queryAll.ts:23</a></li>
-							</ul>
-						</aside>
-						<h4 class="tsd-type-parameters-title">Type parameters</h4>
-						<ul class="tsd-type-parameters">
-							<li>
-								<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">SVGElementTagNameMap</span></h4>
-							</li>
-						</ul>
-						<h4 class="tsd-parameters-title">Parameters</h4>
-						<ul class="tsd-parameters">
-							<li>
-								<h5>selector: <span class="tsd-signature-type">K</span></h5>
-							</li>
-							<li>
-								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-							</li>
-						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
-					</li>
-					<li class="tsd-description">
-						<aside class="tsd-sources">
-							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L24">queryAll.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryAll.ts#L25">queryAll.ts:25</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3899,7 +3875,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryWithin.ts#L51">queryWithin.ts:51</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryWithin.ts#L34">queryWithin.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3912,17 +3888,14 @@ img {
 								<dd><pre><code class="language-typescript"><span style="color: #D32F2F">declare</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">scope</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLElement</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">queryFn</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryWithin</span><span style="color: #24292EFF">(scope)</span>
 
-<span style="color: #C2C3C5">// Recognizes keys of HTMLElementTagNameMap - links: HTMLAnchorElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">links</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;a&#039;</span><span style="color: #24292EFF">)</span>
-
-<span style="color: #C2C3C5">// Recognizes keys of SVGElementTagNameMap - paths: SVGPathElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">paths</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;path&#039;</span><span style="color: #24292EFF">)</span>
-
-<span style="color: #C2C3C5">// takes an explicit element type for other selectors - buttons: HTMLButtonElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into an element type.</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">headings</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;h2.large-heading, h3.medium-heading&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLHeadingElement[]</span>
 
 <span style="color: #C2C3C5">// defaults to Element for element types - others: Element[]</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">others</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;.other&#039;</span><span style="color: #24292EFF">)</span>
+
+<span style="color: #C2C3C5">// takes an explicit element type for other selectors - buttons: HTMLButtonElement[]</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
 
 <span style="color: #C2C3C5">// You can call queryWithin in one go, and still provide type arguments:</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons2</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryWithin</span><span style="color: #24292EFF">(scope)&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
@@ -3951,7 +3924,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/readDataset.ts#L20">readDataset.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/readDataset.ts#L20">readDataset.ts:20</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4007,7 +3980,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/readDataset.ts#L30">readDataset.ts:30</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/readDataset.ts#L30">readDataset.ts:30</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4090,7 +4063,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/remove.ts#L5">remove.ts:5</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/remove.ts#L5">remove.ts:5</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4120,7 +4093,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClasses.ts#L24">removeClasses.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClasses.ts#L24">removeClasses.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4187,7 +4160,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClassesForMS.ts#L17">removeClassesForMS.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClassesForMS.ts#L17">removeClassesForMS.ts:17</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4252,7 +4225,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClassesForNFrames.ts#L19">removeClassesForNFrames.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClassesForNFrames.ts#L19">removeClassesForNFrames.ts:19</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4317,7 +4290,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/setMeta.ts#L21">setMeta.ts:21</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/setMeta.ts#L21">setMeta.ts:21</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4382,7 +4355,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/show.ts#L25">show.ts:25</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/show.ts#L25">show.ts:25</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4428,7 +4401,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/showIf.ts#L34">showIf.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/showIf.ts#L34">showIf.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4497,7 +4470,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/showUsing.ts#L31">showUsing.ts:31</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/showUsing.ts#L31">showUsing.ts:31</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4585,7 +4558,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/style.ts#L27">style.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/style.ts#L27">style.ts:27</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4655,7 +4628,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/toggleClasses.ts#L33">toggleClasses.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/toggleClasses.ts#L33">toggleClasses.ts:33</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4732,58 +4705,87 @@ img {
 				<a name="touchall" class="tsd-anchor"></a>
 				<h3>touch<wbr>All</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, S7, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, T7, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, S7, S8, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, T7, T8, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T7</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T8</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L44">touchAll.ts:44</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L67">touchAll.ts:67</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
-								<p>Takes an array of selectors and a callback function. When for all selectors an element is found, the callback
-								is called with each found element in order. Optionally takes a scope as third argument to use for the element search.</p>
+								<p>Takes an array of CSS-style element selectors and a callback function. When for all selectors an element is found,
+									the callback is called with each found element in order. Optionally takes a scope as third argument to use for the
+								element search.</p>
 							</div>
 							<p>Note: <code>touchAll</code> has overloads for tuples of up to 8 selectors.</p>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Either specify the element types in the callback</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultA</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">], (</span>
-<span style="color: #24292EFF">    button</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    form</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
-<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// do something with button and form...</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;button.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article form#the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// button is HTMLButtonElement</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// form is HTMLFormElement</span>
 <span style="color: #24292EFF">})</span>
 
-<span style="color: #C2C3C5">// or provide them as type arguments list, in which case</span>
-<span style="color: #C2C3C5">// the return type for `touchAll` itself is required:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors all element types default to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultB</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">, </span><span style="color: #1976D2">string</span><span style="color: #24292EFF">&gt;([</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
 <span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">], (</span>
-<span style="color: #24292EFF">    button,</span>
-<span style="color: #24292EFF">    form,</span>
-<span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
-<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// do something with button and form...</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// button is Element</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// form is Element</span>
 <span style="color: #24292EFF">})</span>
 
-<span style="color: #C2C3C5">// and because the queries can fail:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selectors you can</span>
+<span style="color: #C2C3C5">// specify the types explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">type</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">null</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">|</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span>
+<span style="color: #C2C3C5">// Either let the callback specify the element types, this also works for</span>
+<span style="color: #C2C3C5">// referenced functions that satisfy the expected signature:</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultC</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, form</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// ...</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// or provide the element types as type arguments list:</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultD</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">&gt;([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// ...</span>
+<span style="color: #24292EFF">})</span>
 </code></pre>
 								</dd>
 							</dl>
@@ -4791,25 +4793,75 @@ img {
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An array of CSS-style selectors. For each selector an element will be searched.</p>
+								</div>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>The callback to execute when all elements are found.</p>
+								</div>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element queries.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L71">touchAll.ts:71</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
 								<h4>T1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An array of CSS-compatible selectors. For each selector an element will be searched.</p>
-								</div>
 							</li>
 							<li>
 								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>The callback to execute when all elements are found.</p>
-								</div>
 								<ul class="tsd-parameters">
 									<li class="tsd-parameter-signature">
 										<ul class="tsd-signatures tsd-kind-type-literal">
@@ -4831,9 +4883,6 @@ img {
 							</li>
 							<li>
 								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element queries.</p>
-								</div>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -4841,7 +4890,60 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L45">touchAll.ts:45</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L75">touchAll.ts:75</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L80">touchAll.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4853,7 +4955,7 @@ img {
 								<h4>T2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -4894,7 +4996,66 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L46">touchAll.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L85">touchAll.ts:85</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L91">touchAll.ts:91</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4909,7 +5070,7 @@ img {
 								<h4>T3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -4953,7 +5114,72 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L47">touchAll.ts:47</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L97">touchAll.ts:97</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L104">touchAll.ts:104</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4971,7 +5197,7 @@ img {
 								<h4>T4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5018,7 +5244,78 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L48">touchAll.ts:48</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L111">touchAll.ts:111</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L119">touchAll.ts:119</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5039,7 +5336,7 @@ img {
 								<h4>T5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5089,7 +5386,84 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L49">touchAll.ts:49</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L127">touchAll.ts:127</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L136">touchAll.ts:136</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5113,7 +5487,7 @@ img {
 								<h4>T6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5166,7 +5540,90 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L50">touchAll.ts:50</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L145">touchAll.ts:145</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v7: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L155">touchAll.ts:155</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5193,7 +5650,7 @@ img {
 								<h4>T7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5249,7 +5706,96 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L51">touchAll.ts:51</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L165">touchAll.ts:165</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v7: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v8: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L176">touchAll.ts:176</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5279,7 +5825,7 @@ img {
 								<h4>T8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5341,46 +5887,96 @@ img {
 				<a name="touchallp" class="tsd-anchor"></a>
 				<h3>touch<wbr>AllP</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6, S7&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6, T7&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6, S7, S8&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6, T7, T8&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T8</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L32">touchAllP.ts:32</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L46">touchAllP.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
-								<p>Takes an array of selectors. Returns a promise that will only resolve when for all selectors an element is found.
+								<p>Takes an array of CSS-style selectors. Returns a promise that will only resolve when for all selectors an element is found.
 									The promise value is an array of the elements in the order of the selector array. Optionally takes a scope as
 								third argument to use for the element search.</p>
 							</div>
-							<p>This function is useful as an alternative for <code>touchAll</code> in async functions. When <code>await</code>ed  it&#39;ll block
-							all further execution of the function when not all elements are found.</p>
 							<p>Note: <code>touchAllP</code> has overloads for tuples of up to 8 selectors.</p>
 							<p>Like <a href="modules.html#touchall"><code>touchAll</code></a> but &#39;portable&#39;, so that many callbacks can subscribe
 							to the &#39;event&#39; of the elements being found.</p>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Without explicit type arguments:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;button.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;form#the-form&#039;</span><span style="color: #24292EFF">])</span>
+<span style="color: #C2C3C5">// &gt; Promise&lt;[HTMLButtonElement, HTMLFormElement]&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors all element types default to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
 <span style="color: #C2C3C5">// &gt; Promise&lt;[Element, Element]&gt;</span>
 
-<span style="color: #C2C3C5">// With explicit type arguments:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selectors you can</span>
+<span style="color: #C2C3C5">// specify the types explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">&gt;([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
 <span style="color: #C2C3C5">// &gt; Promise&lt;[HTMLButtonElement, HTMLFormElement]&gt;</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An array of CSS-style selectors. For each selector an element will be searched.</p>
+								</div>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element queries.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L49">touchAllP.ts:49</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5391,15 +5987,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An array of CSS-compatible selectors. For each selector an element will be searched.</p>
-								</div>
 							</li>
 							<li>
 								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element queries.</p>
-								</div>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -5407,7 +5997,33 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L33">touchAllP.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L52">touchAllP.ts:52</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L56">touchAllP.ts:56</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5433,7 +6049,36 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L34">touchAllP.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L60">touchAllP.ts:60</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L65">touchAllP.ts:65</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5462,7 +6107,39 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L35">touchAllP.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L70">touchAllP.ts:70</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L76">touchAllP.ts:76</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5494,7 +6171,42 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L36">touchAllP.ts:36</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L82">touchAllP.ts:82</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L89">touchAllP.ts:89</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5529,7 +6241,45 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L37">touchAllP.ts:37</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L96">touchAllP.ts:96</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L104">touchAllP.ts:104</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5567,7 +6317,48 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L38">touchAllP.ts:38</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L112">touchAllP.ts:112</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L121">touchAllP.ts:121</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5608,7 +6399,51 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L39">touchAllP.ts:39</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L130">touchAllP.ts:130</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L140">touchAllP.ts:140</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5655,13 +6490,14 @@ img {
 				<a name="touchelement" class="tsd-anchor"></a>
 				<h3>touch<wbr>Element</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>Element&lt;S, U&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>Element&lt;T, U&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchElement.ts#L20">touchElement.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElement.ts#L53">touchElement.ts:53</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5673,15 +6509,102 @@ img {
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// The callback&#039;s return value is returned from touchElement:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">inputValue</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLInputElement</span><span style="color: #24292EFF">)</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">input</span><span style="color: #24292EFF">.value)</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #C2C3C5">// and because the query for &#039;#my-input&#039; can fail:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;input#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// input is HTMLInputElement</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors the element type defaults to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// input is Element</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selector you can</span>
+<span style="color: #C2C3C5">// specify the type explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #C2C3C5">// Either let the callback specify the element types:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLElement</span><span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> { </span><span style="color: #D32F2F">...</span><span style="color: #24292EFF"> })s</span>
+
+<span style="color: #C2C3C5">// or provide the element type as type argument:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> { </span><span style="color: #D32F2F">...</span><span style="color: #24292EFF"> })</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// The callback&#039;s return value is returned from touchElement:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">result</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;input#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">input</span><span style="color: #24292EFF">.value)</span>
+
+<span style="color: #C2C3C5">// and because the query for &#039;input#my-input&#039; can fail to find an element:</span>
 <span style="color: #D32F2F">type</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">|</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">null</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>A CSS-compatible selector to match the searched element against.</p>
+								</div>
+							</li>
+							<li>
+								<h5>callback: <span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>The callback to execute when the element is found.</p>
+								</div>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>element: <span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element query.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElement.ts#L54">touchElement.ts:54</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5695,15 +6618,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selector: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>A CSS-compatible selector to match the searched element against.</p>
-								</div>
 							</li>
 							<li>
 								<h5>callback: <span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>The callback to execute when the element is found.</p>
-								</div>
 								<ul class="tsd-parameters">
 									<li class="tsd-parameter-signature">
 										<ul class="tsd-signatures tsd-kind-type-literal">
@@ -5724,10 +6641,7 @@ img {
 								</ul>
 							</li>
 							<li>
-								<h5>scope: <span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol"> = ...</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element query.</p>
-								</div>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -5738,13 +6652,14 @@ img {
 				<a name="touchelementp" class="tsd-anchor"></a>
 				<h3>touch<wbr>ElementP</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>ElementP&lt;S&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>ElementP&lt;T&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchElementP.ts#L17">touchElementP.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElementP.ts#L39">touchElementP.ts:39</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5756,11 +6671,61 @@ img {
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">button</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">await</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;form.my-form button#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;HTMLButtonElement&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors the element type defaults to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;Element&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selector you can</span>
+<span style="color: #C2C3C5">// specify the type explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;HTMLButtonElement&gt;</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>A CSS-compatible selector to match the searched element against.</p>
+								</div>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element query.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElementP.ts#L40">touchElementP.ts:40</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5771,15 +6736,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selector: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>A CSS-compatible selector to match the searched element against.</p>
-								</div>
 							</li>
 							<li>
-								<h5>scope: <span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol"> = ...</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element query.</p>
-								</div>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -5796,7 +6755,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/windowLoadP.ts#L9">windowLoadP.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/windowLoadP.ts#L9">windowLoadP.ts:9</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5821,7 +6780,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/writeDataset.ts#L17">writeDataset.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/writeDataset.ts#L17">writeDataset.ts:17</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/scopedcssqueryfunction.html
+++ b/docs/interfaces/scopedcssqueryfunction.html
@@ -2831,15 +2831,14 @@ img {
 		<section class="tsd-panel">
 			<h3 class="tsd-before-signature">Callable</h3>
 			<ul class="tsd-signatures tsd-kind-interface tsd-has-type-parameter">
-				<li class="tsd-signature tsd-kind-icon">Scoped<wbr>Css<wbr>Query<wbr>Function&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
-				<li class="tsd-signature tsd-kind-icon">Scoped<wbr>Css<wbr>Query<wbr>Function&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
+				<li class="tsd-signature tsd-kind-icon">Scoped<wbr>Css<wbr>Query<wbr>Function&lt;S&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></li>
 				<li class="tsd-signature tsd-kind-icon">Scoped<wbr>Css<wbr>Query<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span></li>
 			</ul>
 			<ul class="tsd-descriptions">
 				<li class="tsd-description">
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryWithin.ts#L6">queryWithin.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryWithin.ts#L7">queryWithin.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -2850,52 +2849,21 @@ img {
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
 					<ul class="tsd-type-parameters">
 						<li>
-							<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">HTMLElementTagNameMap</span></h4>
+							<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
 						</li>
 					</ul>
 					<h4 class="tsd-parameters-title">Parameters</h4>
 					<ul class="tsd-parameters">
 						<li>
-							<h5>selector: <span class="tsd-signature-type">K</span></h5>
-							<div class="tsd-comment tsd-typography">
-								<p>An HTML element selector</p>
-							</div>
+							<h5>selector: <span class="tsd-signature-type">S</span></h5>
 						</li>
 					</ul>
-					<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
+					<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></h4>
 				</li>
 				<li class="tsd-description">
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryWithin.ts#L11">queryWithin.ts:11</a></li>
-						</ul>
-					</aside>
-					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>The call signatures for functions returned from <a href="../modules.html#querywithin"><code>queryWithin()</code></a>.</p>
-						</div>
-					</div>
-					<h4 class="tsd-type-parameters-title">Type parameters</h4>
-					<ul class="tsd-type-parameters">
-						<li>
-							<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">SVGElementTagNameMap</span></h4>
-						</li>
-					</ul>
-					<h4 class="tsd-parameters-title">Parameters</h4>
-					<ul class="tsd-parameters">
-						<li>
-							<h5>selector: <span class="tsd-signature-type">K</span></h5>
-							<div class="tsd-comment tsd-typography">
-								<p>An SVG element selector</p>
-							</div>
-						</li>
-					</ul>
-					<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
-				</li>
-				<li class="tsd-description">
-					<aside class="tsd-sources">
-						<ul>
-							<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryWithin.ts#L17">queryWithin.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryWithin.ts#L8">queryWithin.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -2913,9 +2881,6 @@ img {
 					<ul class="tsd-parameters">
 						<li>
 							<h5>selector: <span class="tsd-signature-type">string</span></h5>
-							<div class="tsd-comment tsd-typography">
-								<p>A non-element CSS selector</p>
-							</div>
 						</li>
 					</ul>
 					<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -2901,7 +2901,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">Css<wbr>Display<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;block&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;contents&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;flex&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;grid&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inherit&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;initial&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-block&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-flex&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-grid&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;inline-table&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;list-item&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;none&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;run-in&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-caption&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-cell&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-column&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-column-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-footer-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-header-group&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-row&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;table-row-group&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/_types.ts#L7">_types.ts:7</a></li>
+						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/_types.ts#L7">_types.ts:7</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2919,7 +2919,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">Stylable<wbr>Element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ElementCSSInlineStyle</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/_types.ts#L41">_types.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/_types.ts#L41">_types.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2944,7 +2944,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/DOMReadyP.ts#L9">DOMReadyP.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/DOMReadyP.ts#L9">DOMReadyP.ts:9</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2969,7 +2969,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClasses.ts#L24">addClasses.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClasses.ts#L24">addClasses.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3037,7 +3037,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClassesForMS.ts#L18">addClassesForMS.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClassesForMS.ts#L18">addClassesForMS.ts:18</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3102,7 +3102,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/addClassesForNFrames.ts#L19">addClassesForNFrames.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/addClassesForNFrames.ts#L19">addClassesForNFrames.ts:19</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3167,7 +3167,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/deferFrames.ts#L28">deferFrames.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/deferFrames.ts#L28">deferFrames.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3238,7 +3238,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/deferFramesP.ts#L20">deferFramesP.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/deferFramesP.ts#L20">deferFramesP.ts:20</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3281,7 +3281,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/display.ts#L34">display.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/display.ts#L34">display.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3358,7 +3358,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/displayIf.ts#L28">displayIf.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/displayIf.ts#L28">displayIf.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3429,7 +3429,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/displayUsing.ts#L28">displayUsing.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/displayUsing.ts#L28">displayUsing.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3519,7 +3519,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/getMeta.ts#L42">getMeta.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/getMeta.ts#L42">getMeta.ts:42</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3564,7 +3564,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/getMeta.ts#L85">getMeta.ts:85</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/getMeta.ts#L85">getMeta.ts:85</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3648,7 +3648,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/hide.ts#L21">hide.ts:21</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/hide.ts#L21">hide.ts:21</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3692,7 +3692,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/onDOMReady.ts#L12">onDOMReady.ts:12</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/onDOMReady.ts#L12">onDOMReady.ts:12</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3742,7 +3742,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/onWindowLoad.ts#L12">onWindowLoad.ts:12</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/onWindowLoad.ts#L12">onWindowLoad.ts:12</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3786,33 +3786,32 @@ img {
 				<a name="queryall" class="tsd-anchor"></a>
 				<h3>query<wbr>All</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
-					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
-					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;K&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">K</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></li>
+					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;S&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></li>
 					<li class="tsd-signature tsd-kind-icon">query<wbr>All&lt;T&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L22">queryAll.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryAll.ts#L24">queryAll.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
 								<p>Calls <code>querySelectorAll</code> with given <code>selector</code> on given <code>scope</code>, or on <code>document</code> by default when the
-								scope is omitted. Returns an array containing the found elements.</p>
+									scope is omitted. Returns an array containing the found elements. Attempts to parse the given CSS selector
+								to determine the element type.</p>
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Recognizes keys of HTMLElementTagNameMap:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">anchors</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;a&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLAnchorElement[]</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into an element type.</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">headings</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;h2.large-heading, h3.medium-heading&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLHeadingElement[]</span>
 
-<span style="color: #C2C3C5">// Recognizes keys of SVGElementTagNameMap:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">paths</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;path&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// SVGPathElement[]</span>
+<span style="color: #C2C3C5">// Defaults to Element for unrecognised selectors:</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">components</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;custom-web-component&#039;</span><span style="color: #24292EFF">)              </span><span style="color: #C2C3C5">// Element[]</span>
 
-<span style="color: #C2C3C5">// Defaults to Element, or accepts an explicit type argument for the searched elements:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elements</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;.some-element&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// Element[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLButtonElement[]</span>
+<span style="color: #C2C3C5">// Accepts an explicit type argument for the searched elements:</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">components</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">MyComponent</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;custom-web-component&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// MyComponent[]</span>
 </code></pre>
 								</dd>
 							</dl>
@@ -3820,13 +3819,13 @@ img {
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
-								<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">HTMLElementTagNameMap</span></h4>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
 						<ul class="tsd-parameters">
 							<li>
-								<h5>selector: <span class="tsd-signature-type">K</span></h5>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
 								<div class="tsd-comment tsd-typography">
 									<p>The selector to match elements against.</p>
 								</div>
@@ -3838,35 +3837,12 @@ img {
 								</div>
 							</li>
 						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">HTMLElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></h4>
 					</li>
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L23">queryAll.ts:23</a></li>
-							</ul>
-						</aside>
-						<h4 class="tsd-type-parameters-title">Type parameters</h4>
-						<ul class="tsd-type-parameters">
-							<li>
-								<h4>K<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">SVGElementTagNameMap</span></h4>
-							</li>
-						</ul>
-						<h4 class="tsd-parameters-title">Parameters</h4>
-						<ul class="tsd-parameters">
-							<li>
-								<h5>selector: <span class="tsd-signature-type">K</span></h5>
-							</li>
-							<li>
-								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-							</li>
-						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">SVGElementTagNameMap</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[]</span></h4>
-					</li>
-					<li class="tsd-description">
-						<aside class="tsd-sources">
-							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryAll.ts#L24">queryAll.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryAll.ts#L25">queryAll.ts:25</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3898,7 +3874,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/queryWithin.ts#L51">queryWithin.ts:51</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/queryWithin.ts#L34">queryWithin.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3911,17 +3887,14 @@ img {
 								<dd><pre><code class="language-typescript"><span style="color: #D32F2F">declare</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">scope</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLElement</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">queryFn</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryWithin</span><span style="color: #24292EFF">(scope)</span>
 
-<span style="color: #C2C3C5">// Recognizes keys of HTMLElementTagNameMap - links: HTMLAnchorElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">links</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;a&#039;</span><span style="color: #24292EFF">)</span>
-
-<span style="color: #C2C3C5">// Recognizes keys of SVGElementTagNameMap - paths: SVGPathElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">paths</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;path&#039;</span><span style="color: #24292EFF">)</span>
-
-<span style="color: #C2C3C5">// takes an explicit element type for other selectors - buttons: HTMLButtonElement[]</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into an element type.</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">headings</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;h2.large-heading, h3.medium-heading&#039;</span><span style="color: #24292EFF">) </span><span style="color: #C2C3C5">// HTMLHeadingElement[]</span>
 
 <span style="color: #C2C3C5">// defaults to Element for element types - others: Element[]</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">others</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;.other&#039;</span><span style="color: #24292EFF">)</span>
+
+<span style="color: #C2C3C5">// takes an explicit element type for other selectors - buttons: HTMLButtonElement[]</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryFn</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
 
 <span style="color: #C2C3C5">// You can call queryWithin in one go, and still provide type arguments:</span>
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">buttons2</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">queryWithin</span><span style="color: #24292EFF">(scope)&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;.button&#039;</span><span style="color: #24292EFF">)</span>
@@ -3950,7 +3923,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/readDataset.ts#L20">readDataset.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/readDataset.ts#L20">readDataset.ts:20</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4006,7 +3979,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/readDataset.ts#L30">readDataset.ts:30</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/readDataset.ts#L30">readDataset.ts:30</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4089,7 +4062,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/remove.ts#L5">remove.ts:5</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/remove.ts#L5">remove.ts:5</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4119,7 +4092,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClasses.ts#L24">removeClasses.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClasses.ts#L24">removeClasses.ts:24</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4186,7 +4159,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClassesForMS.ts#L17">removeClassesForMS.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClassesForMS.ts#L17">removeClassesForMS.ts:17</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4251,7 +4224,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/removeClassesForNFrames.ts#L19">removeClassesForNFrames.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/removeClassesForNFrames.ts#L19">removeClassesForNFrames.ts:19</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4316,7 +4289,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/setMeta.ts#L21">setMeta.ts:21</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/setMeta.ts#L21">setMeta.ts:21</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4381,7 +4354,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/show.ts#L25">show.ts:25</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/show.ts#L25">show.ts:25</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4427,7 +4400,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/showIf.ts#L34">showIf.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/showIf.ts#L34">showIf.ts:34</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4496,7 +4469,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/showUsing.ts#L31">showUsing.ts:31</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/showUsing.ts#L31">showUsing.ts:31</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4584,7 +4557,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/style.ts#L27">style.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/style.ts#L27">style.ts:27</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4654,7 +4627,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/toggleClasses.ts#L33">toggleClasses.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/toggleClasses.ts#L33">toggleClasses.ts:33</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -4731,58 +4704,87 @@ img {
 				<a name="touchall" class="tsd-anchor"></a>
 				<h3>touch<wbr>All</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, S7, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, T7, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;S1, S2, S3, S4, S5, S6, S7, S8, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>All&lt;T1, T2, T3, T4, T5, T6, T7, T8, U&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, cb<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T2</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T3</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T4</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T5</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T6</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T7</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T8</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L44">touchAll.ts:44</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L67">touchAll.ts:67</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
-								<p>Takes an array of selectors and a callback function. When for all selectors an element is found, the callback
-								is called with each found element in order. Optionally takes a scope as third argument to use for the element search.</p>
+								<p>Takes an array of CSS-style element selectors and a callback function. When for all selectors an element is found,
+									the callback is called with each found element in order. Optionally takes a scope as third argument to use for the
+								element search.</p>
 							</div>
 							<p>Note: <code>touchAll</code> has overloads for tuples of up to 8 selectors.</p>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Either specify the element types in the callback</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultA</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">], (</span>
-<span style="color: #24292EFF">    button</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    form</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
-<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// do something with button and form...</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;button.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article form#the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// button is HTMLButtonElement</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// form is HTMLFormElement</span>
 <span style="color: #24292EFF">})</span>
 
-<span style="color: #C2C3C5">// or provide them as type arguments list, in which case</span>
-<span style="color: #C2C3C5">// the return type for `touchAll` itself is required:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors all element types default to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultB</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">, </span><span style="color: #1976D2">string</span><span style="color: #24292EFF">&gt;([</span>
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
 <span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">,</span>
-<span style="color: #24292EFF">], (</span>
-<span style="color: #24292EFF">    button,</span>
-<span style="color: #24292EFF">    form,</span>
-<span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
-<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// do something with button and form...</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// button is Element</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// form is Element</span>
 <span style="color: #24292EFF">})</span>
 
-<span style="color: #C2C3C5">// and because the queries can fail:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selectors you can</span>
+<span style="color: #C2C3C5">// specify the types explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #D32F2F">type</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">null</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">|</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span>
+<span style="color: #C2C3C5">// Either let the callback specify the element types, this also works for</span>
+<span style="color: #C2C3C5">// referenced functions that satisfy the expected signature:</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultC</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, form</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// ...</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// or provide the element types as type arguments list:</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">resultD</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAll</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">&gt;([</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">    </span><span style="color: #22863A">&#039;.article #the-form&#039;</span><span style="color: #24292EFF">,</span>
+<span style="color: #24292EFF">], (button, form) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// ...</span>
+<span style="color: #24292EFF">})</span>
 </code></pre>
 								</dd>
 							</dl>
@@ -4790,25 +4792,75 @@ img {
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An array of CSS-style selectors. For each selector an element will be searched.</p>
+								</div>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>The callback to execute when all elements are found.</p>
+								</div>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element queries.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L71">touchAll.ts:71</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
 								<h4>T1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An array of CSS-compatible selectors. For each selector an element will be searched.</p>
-								</div>
 							</li>
 							<li>
 								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>The callback to execute when all elements are found.</p>
-								</div>
 								<ul class="tsd-parameters">
 									<li class="tsd-parameter-signature">
 										<ul class="tsd-signatures tsd-kind-type-literal">
@@ -4830,9 +4882,6 @@ img {
 							</li>
 							<li>
 								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element queries.</p>
-								</div>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -4840,7 +4889,60 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L45">touchAll.ts:45</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L75">touchAll.ts:75</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L80">touchAll.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4852,7 +4954,7 @@ img {
 								<h4>T2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -4893,7 +4995,66 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L46">touchAll.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L85">touchAll.ts:85</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L91">touchAll.ts:91</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4908,7 +5069,7 @@ img {
 								<h4>T3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -4952,7 +5113,72 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L47">touchAll.ts:47</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L97">touchAll.ts:97</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L104">touchAll.ts:104</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -4970,7 +5196,7 @@ img {
 								<h4>T4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5017,7 +5243,78 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L48">touchAll.ts:48</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L111">touchAll.ts:111</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L119">touchAll.ts:119</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5038,7 +5335,7 @@ img {
 								<h4>T5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5088,7 +5385,84 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L49">touchAll.ts:49</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L127">touchAll.ts:127</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L136">touchAll.ts:136</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5112,7 +5486,7 @@ img {
 								<h4>T6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5165,7 +5539,90 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L50">touchAll.ts:50</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L145">touchAll.ts:145</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v7: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L155">touchAll.ts:155</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5192,7 +5649,7 @@ img {
 								<h4>T7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5248,7 +5705,96 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAll.ts#L51">touchAll.ts:51</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L165">touchAll.ts:165</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5>cb: <span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>v1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span>, v2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span>, v3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span>, v4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span>, v5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span>, v6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span>, v7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span>, v8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>v1: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v2: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v3: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v4: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v5: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v6: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v7: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+													<li>
+														<h5>v8: <span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAll.ts#L176">touchAll.ts:176</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5278,7 +5824,7 @@ img {
 								<h4>T8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span></h4>
 							</li>
 							<li>
-								<h4>U</h4>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
 							</li>
 						</ul>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -5340,46 +5886,96 @@ img {
 				<a name="touchallp" class="tsd-anchor"></a>
 				<h3>touch<wbr>AllP</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6, S7&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6, T7&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;S1, S2, S3, S4, S5, S6, S7, S8&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>AllP&lt;T1, T2, T3, T4, T5, T6, T7, T8&gt;<span class="tsd-signature-symbol">(</span>selectors<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">T8</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L32">touchAllP.ts:32</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L46">touchAllP.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
-								<p>Takes an array of selectors. Returns a promise that will only resolve when for all selectors an element is found.
+								<p>Takes an array of CSS-style selectors. Returns a promise that will only resolve when for all selectors an element is found.
 									The promise value is an array of the elements in the order of the selector array. Optionally takes a scope as
 								third argument to use for the element search.</p>
 							</div>
-							<p>This function is useful as an alternative for <code>touchAll</code> in async functions. When <code>await</code>ed  it&#39;ll block
-							all further execution of the function when not all elements are found.</p>
 							<p>Note: <code>touchAllP</code> has overloads for tuples of up to 8 selectors.</p>
 							<p>Like <a href="modules.html#touchall"><code>touchAll</code></a> but &#39;portable&#39;, so that many callbacks can subscribe
 							to the &#39;event&#39; of the elements being found.</p>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// Without explicit type arguments:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPA</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;button.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;form#the-form&#039;</span><span style="color: #24292EFF">])</span>
+<span style="color: #C2C3C5">// &gt; Promise&lt;[HTMLButtonElement, HTMLFormElement]&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors all element types default to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
 <span style="color: #C2C3C5">// &gt; Promise&lt;[Element, Element]&gt;</span>
 
-<span style="color: #C2C3C5">// With explicit type arguments:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selectors you can</span>
+<span style="color: #C2C3C5">// specify the types explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
 <span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">elementsPB</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchAllP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">, </span><span style="color: #6F42C1">HTMLFormElement</span><span style="color: #24292EFF">&gt;([</span><span style="color: #22863A">&#039;.my-button&#039;</span><span style="color: #24292EFF">, </span><span style="color: #22863A">&#039;#the-form&#039;</span><span style="color: #24292EFF">])</span>
 <span style="color: #C2C3C5">// &gt; Promise&lt;[HTMLButtonElement, HTMLFormElement]&gt;</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">]</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An array of CSS-style selectors. For each selector an element will be searched.</p>
+								</div>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element queries.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L49">touchAllP.ts:49</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5390,15 +5986,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An array of CSS-compatible selectors. For each selector an element will be searched.</p>
-								</div>
 							</li>
 							<li>
 								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element queries.</p>
-								</div>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">T1</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -5406,7 +5996,33 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L33">touchAllP.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L52">touchAllP.ts:52</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L56">touchAllP.ts:56</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5432,7 +6048,36 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L34">touchAllP.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L60">touchAllP.ts:60</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L65">touchAllP.ts:65</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5461,7 +6106,39 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L35">touchAllP.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L70">touchAllP.ts:70</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L76">touchAllP.ts:76</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5493,7 +6170,42 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L36">touchAllP.ts:36</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L82">touchAllP.ts:82</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L89">touchAllP.ts:89</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5528,7 +6240,45 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L37">touchAllP.ts:37</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L96">touchAllP.ts:96</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L104">touchAllP.ts:104</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5566,7 +6316,48 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L38">touchAllP.ts:38</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L112">touchAllP.ts:112</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L121">touchAllP.ts:121</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5607,7 +6398,51 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchAllP.ts#L39">touchAllP.ts:39</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L130">touchAllP.ts:130</a></li>
+							</ul>
+						</aside>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S6<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S7<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>S8<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selectors: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">]</span></h5>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S1</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S2</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S3</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S4</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S5</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S6</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S7</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S8</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchAllP.ts#L140">touchAllP.ts:140</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -5654,13 +6489,14 @@ img {
 				<a name="touchelement" class="tsd-anchor"></a>
 				<h3>touch<wbr>Element</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>Element&lt;S, U&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>Element&lt;T, U&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchElement.ts#L20">touchElement.ts:20</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElement.ts#L53">touchElement.ts:53</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5672,15 +6508,102 @@ img {
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// The callback&#039;s return value is returned from touchElement:</span>
-<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">inputValue</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLInputElement</span><span style="color: #24292EFF">)</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">input</span><span style="color: #24292EFF">.value)</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
 
-<span style="color: #C2C3C5">// and because the query for &#039;#my-input&#039; can fail:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;input#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// input is HTMLInputElement</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors the element type defaults to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> {</span>
+<span style="color: #24292EFF">    </span><span style="color: #C2C3C5">// input is Element</span>
+<span style="color: #24292EFF">})</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selector you can</span>
+<span style="color: #C2C3C5">// specify the type explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #C2C3C5">// Either let the callback specify the element types:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">HTMLElement</span><span style="color: #24292EFF">) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> { </span><span style="color: #D32F2F">...</span><span style="color: #24292EFF"> })s</span>
+
+<span style="color: #C2C3C5">// or provide the element type as type argument:</span>
+<span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> { </span><span style="color: #D32F2F">...</span><span style="color: #24292EFF"> })</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// The callback&#039;s return value is returned from touchElement:</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">result</span><span style="color: #D32F2F">:</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElement</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;input#my-input&#039;</span><span style="color: #24292EFF">, (input) </span><span style="color: #D32F2F">=&gt;</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">input</span><span style="color: #24292EFF">.value)</span>
+
+<span style="color: #C2C3C5">// and because the query for &#039;input#my-input&#039; can fail to find an element:</span>
 <span style="color: #D32F2F">type</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">TheType</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">string</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">|</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">null</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+							<li>
+								<h4>U = <span class="tsd-signature-type">any</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>A CSS-compatible selector to match the searched element against.</p>
+								</div>
+							</li>
+							<li>
+								<h5>callback: <span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>The callback to execute when the element is found.</p>
+								</div>
+								<ul class="tsd-parameters">
+									<li class="tsd-parameter-signature">
+										<ul class="tsd-signatures tsd-kind-type-literal">
+											<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">U</span></li>
+										</ul>
+										<ul class="tsd-descriptions">
+											<li class="tsd-description">
+												<h4 class="tsd-parameters-title">Parameters</h4>
+												<ul class="tsd-parameters">
+													<li>
+														<h5>element: <span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span></h5>
+													</li>
+												</ul>
+												<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span></h4>
+											</li>
+										</ul>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element query.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElement.ts#L54">touchElement.ts:54</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5694,15 +6617,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selector: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>A CSS-compatible selector to match the searched element against.</p>
-								</div>
 							</li>
 							<li>
 								<h5>callback: <span class="tsd-signature-symbol">(</span>element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>The callback to execute when the element is found.</p>
-								</div>
 								<ul class="tsd-parameters">
 									<li class="tsd-parameter-signature">
 										<ul class="tsd-signatures tsd-kind-type-literal">
@@ -5723,10 +6640,7 @@ img {
 								</ul>
 							</li>
 							<li>
-								<h5>scope: <span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol"> = ...</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element query.</p>
-								</div>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">U</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -5737,13 +6651,14 @@ img {
 				<a name="touchelementp" class="tsd-anchor"></a>
 				<h3>touch<wbr>ElementP</h3>
 				<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+					<li class="tsd-signature tsd-kind-icon">touch<wbr>ElementP&lt;S&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					<li class="tsd-signature tsd-kind-icon">touch<wbr>ElementP&lt;T&gt;<span class="tsd-signature-symbol">(</span>selector<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></li>
 				</ul>
 				<ul class="tsd-descriptions">
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/touchElementP.ts#L17">touchElementP.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElementP.ts#L39">touchElementP.ts:39</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5755,11 +6670,61 @@ img {
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><pre><code class="language-typescript"><span style="color: #D32F2F">const</span><span style="color: #24292EFF"> </span><span style="color: #1976D2">button</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">=</span><span style="color: #24292EFF"> </span><span style="color: #D32F2F">await</span><span style="color: #24292EFF"> </span><span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+								<dd><pre><code class="language-typescript"><span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// Automatically attempts to parse CSS selectors into element types, which</span>
+<span style="color: #C2C3C5">// should work for tag-qualified CSS selectors</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">(</span><span style="color: #22863A">&#039;form.my-form button#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;HTMLButtonElement&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When using non-recognised selectors the element type defaults to `Element`</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;Element&gt;</span>
+
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+<span style="color: #C2C3C5">// When it fails to infer the element types from given CSS selector you can</span>
+<span style="color: #C2C3C5">// specify the type explicitly</span>
+<span style="color: #C2C3C5">// -------------------------------------------------------------------------</span>
+
+<span style="color: #6F42C1">touchElementP</span><span style="color: #24292EFF">&lt;</span><span style="color: #6F42C1">HTMLButtonElement</span><span style="color: #24292EFF">&gt;(</span><span style="color: #22863A">&#039;#my-button&#039;</span><span style="color: #24292EFF">)</span>
+<span style="color: #C2C3C5">// Promise&lt;HTMLButtonElement&gt;</span>
 </code></pre>
 								</dd>
 							</dl>
 						</div>
+						<h4 class="tsd-type-parameters-title">Type parameters</h4>
+						<ul class="tsd-type-parameters">
+							<li>
+								<h4>S<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h4>
+							</li>
+						</ul>
+						<h4 class="tsd-parameters-title">Parameters</h4>
+						<ul class="tsd-parameters">
+							<li>
+								<h5>selector: <span class="tsd-signature-type">S</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>A CSS-compatible selector to match the searched element against.</p>
+								</div>
+							</li>
+							<li>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
+								<div class="tsd-comment tsd-typography">
+									<p>An optional scope for the element query.</p>
+								</div>
+							</li>
+						</ul>
+						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParseSelector</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
+					</li>
+					<li class="tsd-description">
+						<aside class="tsd-sources">
+							<ul>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/touchElementP.ts#L40">touchElementP.ts:40</a></li>
+							</ul>
+						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
 							<li>
@@ -5770,15 +6735,9 @@ img {
 						<ul class="tsd-parameters">
 							<li>
 								<h5>selector: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>A CSS-compatible selector to match the searched element against.</p>
-								</div>
 							</li>
 							<li>
-								<h5>scope: <span class="tsd-signature-type">ParentNode</span><span class="tsd-signature-symbol"> = ...</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An optional scope for the element query.</p>
-								</div>
+								<h5><span class="tsd-flag ts-flagOptional">Optional</span> scope: <span class="tsd-signature-type">ParentNode</span></h5>
 							</li>
 						</ul>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -5795,7 +6754,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/windowLoadP.ts#L9">windowLoadP.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/windowLoadP.ts#L9">windowLoadP.ts:9</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -5820,7 +6779,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/c36baf0/src/writeDataset.ts#L17">writeDataset.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/JJWesterkamp/lambda-dom/blob/fa08392/src/writeDataset.ts#L17">writeDataset.ts:17</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "ts-loader": "^8.0.11",
     "tslib": "^2.0.0",
     "typedoc": "^0.20.34",
-    "typescript": "^4.0.5",
+    "typed-query-selector": "^2.4.1",
+    "typescript": "^4.2",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.2.0"
   }

--- a/src/queryAll.ts
+++ b/src/queryAll.ts
@@ -1,6 +1,9 @@
+import { ParseSelector } from 'typed-query-selector/parser'
+
 /**
  * Calls `querySelectorAll` with given `selector` on given `scope`, or on `document` by default when the
- * scope is omitted. Returns an array containing the found elements.
+ * scope is omitted. Returns an array containing the found elements. Attempts to parse the given CSS selector
+ * to determine the element type.
  *
  * @param selector The selector to match elements against.
  * @param scope The scope of the element query. When omitted `queryAll` performs a global search.
@@ -8,19 +11,17 @@
  * @example
  *
  * ```typescript
- * // Recognizes keys of HTMLElementTagNameMap:
- * const anchors = queryAll('a') // HTMLAnchorElement[]
+ * // Automatically attempts to parse CSS selectors into an element type.
+ * const headings = queryAll('h2.large-heading, h3.medium-heading') // HTMLHeadingElement[]
  *
- * // Recognizes keys of SVGElementTagNameMap:
- * const paths = queryAll('path') // SVGPathElement[]
+ * // Defaults to Element for unrecognised selectors:
+ * const components = queryAll('custom-web-component')              // Element[]
  *
- * // Defaults to Element, or accepts an explicit type argument for the searched elements:
- * const elements = queryAll('.some-element') // Element[]
- * const buttons = queryAll<HTMLButtonElement>('.my-button') // HTMLButtonElement[]
+ * // Accepts an explicit type argument for the searched elements:
+ * const components = queryAll<MyComponent>('custom-web-component') // MyComponent[]
  * ```
  */
-export function queryAll<K extends keyof HTMLElementTagNameMap>(selector: K, scope?: ParentNode): HTMLElementTagNameMap[K][]
-export function queryAll<K extends keyof SVGElementTagNameMap>(selector: K, scope?: ParentNode): SVGElementTagNameMap[K][]
+export function queryAll<S extends string>(selector: S, scope?: ParentNode): ParseSelector<S>[]
 export function queryAll<T extends Element>(selector: string, scope?: ParentNode): T[]
 export function queryAll(selector: string, scope: ParentNode = document) {
     return Array.prototype.slice.call(scope.querySelectorAll(selector))

--- a/src/queryWithin.ts
+++ b/src/queryWithin.ts
@@ -1,25 +1,11 @@
+import { ParseSelector } from 'typed-query-selector/parser'
 import { queryAll } from './queryAll'
 
 /**
  * The call signatures for functions returned from {@link queryWithin `queryWithin()`}.
  */
 export interface ScopedCssQueryFunction {
-    /**
-     * @param {K} selector - An HTML element selector
-     * @return {HTMLElementTagNameMap[K][]}
-     */
-    <K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K][]
-
-    /**
-     * @param {K} selector - An SVG element selector
-     * @return {SVGElementTagNameMap[K][]}
-     */
-    <K extends keyof SVGElementTagNameMap>(selector: K): SVGElementTagNameMap[K][]
-
-    /**
-     * @param {string} selector - A non-element CSS selector
-     * @return {T[]}
-     */
+    <S extends string>(selector: S): ParseSelector<S>[]
     <T extends Element>(selector: string): T[]
 }
 

--- a/src/queryWithin.ts
+++ b/src/queryWithin.ts
@@ -18,17 +18,14 @@ export interface ScopedCssQueryFunction {
  * declare const scope: HTMLElement
  * const queryFn = queryWithin(scope)
  *
- * // Recognizes keys of HTMLElementTagNameMap - links: HTMLAnchorElement[]
- * const links = queryFn('a')
- *
- * // Recognizes keys of SVGElementTagNameMap - paths: SVGPathElement[]
- * const paths = queryFn('path')
- *
- * // takes an explicit element type for other selectors - buttons: HTMLButtonElement[]
- * const buttons = queryFn<HTMLButtonElement>('.button')
+ * // Automatically attempts to parse CSS selectors into an element type.
+ * const headings = queryFn('h2.large-heading, h3.medium-heading') // HTMLHeadingElement[]
  *
  * // defaults to Element for element types - others: Element[]
  * const others = queryFn('.other')
+ *
+ * // takes an explicit element type for other selectors - buttons: HTMLButtonElement[]
+ * const buttons = queryFn<HTMLButtonElement>('.button')
  *
  * // You can call queryWithin in one go, and still provide type arguments:
  * const buttons2 = queryWithin(scope)<HTMLButtonElement>('.button')

--- a/src/touchAll.ts
+++ b/src/touchAll.ts
@@ -1,3 +1,5 @@
+import { ParseSelector as P } from 'typed-query-selector/parser'
+
 /**
  * Takes an array of selectors and a callback function. When for all selectors an element is found, the callback
  * is called with each found element in order. Optionally takes a scope as third argument to use for the element search.
@@ -41,14 +43,126 @@
  * type TheType = null | string
  * ```
  */
-export function touchAll<T1 extends Element, U>(selectors: [string], cb: (v1: T1) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, U>(selectors: [string, string], cb: (v1: T1, v2: T2) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, U>(selectors: [string, string, string], cb: (v1: T1, v2: T2, v3: T3) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, U>(selectors: [string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, U>(selectors: [string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element, U>(selectors: [string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element, T7 extends Element, U>(selectors: [string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7) => U, scope?: ParentNode): U | null
-export function touchAll<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element, T7 extends Element, T8 extends Element, U>(selectors: [string, string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    U
+>(selectors: [S1], cb: (v1: P<S1>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    U
+>(selectors: [string], cb: (v1: T1) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    U
+>(selectors: [S1, S2], cb: (v1: P<S1>, v2: P<S2>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    U
+>(selectors: [string, string], cb: (v1: T1, v2: T2) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    U
+>(selectors: [S1, S2, S3], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    U
+>(selectors: [string, string, string], cb: (v1: T1, v2: T2, v3: T3) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    U
+>(selectors: [S1, S2, S3, S4], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    U
+>(selectors: [string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    U
+>(selectors: [S1, S2, S3, S4, S5], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    U
+>(selectors: [string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string,
+    U
+>(selectors: [S1, S2, S3, S4, S5, S6], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element,
+    U
+>(selectors: [string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string,
+    S7 extends string,
+    U
+>(selectors: [S1, S2, S3, S4, S5, S6, S7], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>, v7: P<S7>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element,
+    T7 extends Element,
+    U
+>(selectors: [string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7) => U, scope?: ParentNode): U | null
+export function touchAll<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string,
+    S7 extends string,
+    S8 extends string,
+    U
+>(selectors: [S1, S2, S3, S4, S5, S6, S7, S8], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>, v7: P<S7>, v8: P<S8>) => U, scope?: ParentNode): U | null
+export function touchAll<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element,
+    T7 extends Element,
+    T8 extends Element,
+    U
+>(selectors: [string, string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8) => U, scope?: ParentNode): U | null
 export function touchAll(selectors: string[], cb: Function, scope: ParentNode = document) {
 
     const elements: Element[] = []

--- a/src/touchAll.ts
+++ b/src/touchAll.ts
@@ -1,91 +1,112 @@
 import { ParseSelector as P } from 'typed-query-selector/parser'
 
 /**
- * Takes an array of selectors and a callback function. When for all selectors an element is found, the callback
- * is called with each found element in order. Optionally takes a scope as third argument to use for the element search.
+ * Takes an array of CSS-style element selectors and a callback function. When for all selectors an element is found,
+ * the callback is called with each found element in order. Optionally takes a scope as third argument to use for the
+ * element search.
  *
  * Note: `touchAll` has overloads for tuples of up to 8 selectors.
  *
- * @param selectors An array of CSS-compatible selectors. For each selector an element will be searched.
+ * @param selectors An array of CSS-style selectors. For each selector an element will be searched.
  * @param cb The callback to execute when all elements are found.
  * @param scope An optional scope for the element queries.
  *
  * @example
  *
  * ```typescript
- * // Either specify the element types in the callback
+ * // -------------------------------------------------------------------------
+ * // Automatically attempts to parse CSS selectors into element types, which
+ * // should work for tag-qualified CSS selectors
+ * // -------------------------------------------------------------------------
  *
- * const resultA: TheType = touchAll([
- *     '.my-button',
- *     '#the-form',
- * ], (
- *     button: HTMLButtonElement,
- *     form: HTMLFormElement,
- * ) => {
- *     // do something with button and form...
+ * const resultA = touchAll([
+ *     'button.my-button',
+ *     '.article form#the-form',
+ * ], (button, form) => {
+ *     // button is HTMLButtonElement
+ *     // form is HTMLFormElement
  * })
  *
- * // or provide them as type arguments list, in which case
- * // the return type for `touchAll` itself is required:
+ * // -------------------------------------------------------------------------
+ * // When using non-recognised selectors all element types default to `Element`
+ * // -------------------------------------------------------------------------
  *
- * const resultB: TheType = touchAll<HTMLButtonElement, HTMLFormElement, string>([
+ * const resultB = touchAll([
  *     '.my-button',
- *     '#the-form',
- * ], (
- *     button,
- *     form,
- * ) => {
- *     // do something with button and form...
+ *     '.article #the-form',
+ * ], (button, form) => {
+ *     // button is Element
+ *     // form is Element
  * })
  *
- * // and because the queries can fail:
+ * // -------------------------------------------------------------------------
+ * // When it fails to infer the element types from given CSS selectors you can
+ * // specify the types explicitly
+ * // -------------------------------------------------------------------------
  *
- * type TheType = null | string
+ * // Either let the callback specify the element types, this also works for
+ * // referenced functions that satisfy the expected signature:
+ *
+ * const resultC = touchAll([
+ *     '.my-button',
+ *     '.article #the-form',
+ * ], (button: HTMLButtonElement, form: HTMLFormElement) => {
+ *     // ...
+ * })
+ *
+ * // or provide the element types as type arguments list:
+ *
+ * const resultD = touchAll<HTMLButtonElement, HTMLFormElement>([
+ *     '.my-button',
+ *     '.article #the-form',
+ * ], (button, form) => {
+ *     // ...
+ * })
  * ```
  */
 export function touchAll<
     S1 extends string,
-    U
+    U = any
 >(selectors: [S1], cb: (v1: P<S1>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
-    U
+    U = any
 >(selectors: [string], cb: (v1: T1) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
     S2 extends string,
-    U
+    U = any
 >(selectors: [S1, S2], cb: (v1: P<S1>, v2: P<S2>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
     T2 extends Element,
-    U
+    U = any
 >(selectors: [string, string], cb: (v1: T1, v2: T2) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
     S2 extends string,
     S3 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
     T2 extends Element,
     T3 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string], cb: (v1: T1, v2: T2, v3: T3) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
     S2 extends string,
     S3 extends string,
     S4 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3, S4], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
     T2 extends Element,
     T3 extends Element,
     T4 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
@@ -93,7 +114,7 @@ export function touchAll<
     S3 extends string,
     S4 extends string,
     S5 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3, S4, S5], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
@@ -101,7 +122,7 @@ export function touchAll<
     T3 extends Element,
     T4 extends Element,
     T5 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
@@ -110,7 +131,7 @@ export function touchAll<
     S4 extends string,
     S5 extends string,
     S6 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3, S4, S5, S6], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
@@ -119,7 +140,7 @@ export function touchAll<
     T4 extends Element,
     T5 extends Element,
     T6 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
@@ -129,7 +150,7 @@ export function touchAll<
     S5 extends string,
     S6 extends string,
     S7 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3, S4, S5, S6, S7], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>, v7: P<S7>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
@@ -139,7 +160,7 @@ export function touchAll<
     T5 extends Element,
     T6 extends Element,
     T7 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7) => U, scope?: ParentNode): U | null
 export function touchAll<
     S1 extends string,
@@ -150,7 +171,7 @@ export function touchAll<
     S6 extends string,
     S7 extends string,
     S8 extends string,
-    U
+    U = any
 >(selectors: [S1, S2, S3, S4, S5, S6, S7, S8], cb: (v1: P<S1>, v2: P<S2>, v3: P<S3>, v4: P<S4>, v5: P<S5>, v6: P<S6>, v7: P<S7>, v8: P<S8>) => U, scope?: ParentNode): U | null
 export function touchAll<
     T1 extends Element,
@@ -161,14 +182,12 @@ export function touchAll<
     T6 extends Element,
     T7 extends Element,
     T8 extends Element,
-    U
+    U = any
 >(selectors: [string, string, string, string, string, string, string, string], cb: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8) => U, scope?: ParentNode): U | null
 export function touchAll(selectors: string[], cb: Function, scope: ParentNode = document) {
-
     const elements: Element[] = []
 
     for (const selector of selectors) {
-
         const el = scope.querySelector(selector)
 
         if (el === null) {

--- a/src/touchAllP.ts
+++ b/src/touchAllP.ts
@@ -4,29 +4,41 @@ import { ParseSelector as P } from 'typed-query-selector/parser'
 
 
 /**
- * Takes an array of selectors. Returns a promise that will only resolve when for all selectors an element is found.
+ * Takes an array of CSS-style selectors. Returns a promise that will only resolve when for all selectors an element is found.
  * The promise value is an array of the elements in the order of the selector array. Optionally takes a scope as
  * third argument to use for the element search.
- *
- * This function is useful as an alternative for `touchAll` in async functions. When `await`ed  it'll block
- * all further execution of the function when not all elements are found.
  *
  * Note: `touchAllP` has overloads for tuples of up to 8 selectors.
  *
  * Like {@linkcode touchAll} but 'portable', so that many callbacks can subscribe
  * to the 'event' of the elements being found.
  *
- * @param selectors An array of CSS-compatible selectors. For each selector an element will be searched.
+ * @param selectors An array of CSS-style selectors. For each selector an element will be searched.
  * @param scope An optional scope for the element queries.
  *
  * @example
  *
  * ```typescript
- * // Without explicit type arguments:
- * const elementsPA = touchAllP(['.my-button', '#the-form'])
+ * // -------------------------------------------------------------------------
+ * // Automatically attempts to parse CSS selectors into element types, which
+ * // should work for tag-qualified CSS selectors
+ * // -------------------------------------------------------------------------
+ *
+ * const elementsPA = touchAllP(['button.my-button', 'form#the-form'])
+ * // > Promise<[HTMLButtonElement, HTMLFormElement]>
+ *
+ * // -------------------------------------------------------------------------
+ * // When using non-recognised selectors all element types default to `Element`
+ * // -------------------------------------------------------------------------
+ *
+ * const elementsPB = touchAllP(['.my-button', '#the-form'])
  * // > Promise<[Element, Element]>
  *
- * // With explicit type arguments:
+ * // -------------------------------------------------------------------------
+ * // When it fails to infer the element types from given CSS selectors you can
+ * // specify the types explicitly
+ * // -------------------------------------------------------------------------
+ *
  * const elementsPB = touchAllP<HTMLButtonElement, HTMLFormElement>(['.my-button', '#the-form'])
  * // > Promise<[HTMLButtonElement, HTMLFormElement]>
  * ```

--- a/src/touchAllP.ts
+++ b/src/touchAllP.ts
@@ -1,5 +1,7 @@
-import { touchAll } from './touchAll'
 import { touchElementP } from './touchElementP'
+import { ParseSelector as P } from 'typed-query-selector/parser'
+
+
 
 /**
  * Takes an array of selectors. Returns a promise that will only resolve when for all selectors an element is found.
@@ -29,14 +31,110 @@ import { touchElementP } from './touchElementP'
  * // > Promise<[HTMLButtonElement, HTMLFormElement]>
  * ```
  */
-export function touchAllP<T1 extends Element>(selectors: [string], scope?: ParentNode): Promise<[T1]>
-export function touchAllP<T1 extends Element, T2 extends Element>(selectors: [string, string], scope?: ParentNode): Promise<[T1, T2]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element>(selectors: [string, string, string], scope?: ParentNode): Promise<[T1, T2, T3]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element>(selectors: [string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element>(selectors: [string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element>(selectors: [string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element, T7 extends Element>(selectors: [string, string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6, T7]>
-export function touchAllP<T1 extends Element, T2 extends Element, T3 extends Element, T4 extends Element, T5 extends Element, T6 extends Element, T7 extends Element, T8 extends Element>(selectors: [string, string, string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>
+export function touchAllP<
+    S1 extends string
+>(selectors: [S1], scope?: ParentNode): Promise<[P<S1>]>
+export function touchAllP<
+    T1 extends Element
+>(selectors: [string], scope?: ParentNode): Promise<[T1]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string
+>(selectors: [S1, S2], scope?: ParentNode): Promise<[P<S1>, P<S2>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element
+>(selectors: [string, string], scope?: ParentNode): Promise<[T1, T2]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string
+>(selectors: [S1, S2, S3], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element
+>(selectors: [string, string, string], scope?: ParentNode): Promise<[T1, T2, T3]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string
+>(selectors: [S1, S2, S3, S4], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>, P<S4>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element
+>(selectors: [string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string
+>(selectors: [S1, S2, S3, S4, S5], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>, P<S4>, P<S5>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element
+>(selectors: [string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string
+>(selectors: [S1, S2, S3, S4, S5, S6], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>, P<S4>, P<S5>, P<S6>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element
+>(selectors: [string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string,
+    S7 extends string
+>(selectors: [S1, S2, S3, S4, S5, S6, S7], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>, P<S4>, P<S5>, P<S6>, P<S7>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element,
+    T7 extends Element
+>(selectors: [string, string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6, T7]>
+export function touchAllP<
+    S1 extends string,
+    S2 extends string,
+    S3 extends string,
+    S4 extends string,
+    S5 extends string,
+    S6 extends string,
+    S7 extends string,
+    S8 extends string
+>(selectors: [S1, S2, S3, S4, S5, S6, S7, S8], scope?: ParentNode): Promise<[P<S1>, P<S2>, P<S3>, P<S4>, P<S5>, P<S6>, P<S7>, P<S8>]>
+export function touchAllP<
+    T1 extends Element,
+    T2 extends Element,
+    T3 extends Element,
+    T4 extends Element,
+    T5 extends Element,
+    T6 extends Element,
+    T7 extends Element,
+    T8 extends Element
+>(selectors: [string, string, string, string, string, string, string, string], scope?: ParentNode): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>
 export function touchAllP(selectors: string[], scope: ParentNode = document) {
     return Promise.all(
         selectors.map((selector) => touchElementP(selector, scope))

--- a/src/touchElement.ts
+++ b/src/touchElement.ts
@@ -12,10 +12,41 @@ import { ParseSelector } from 'typed-query-selector/parser'
  *
  * @example
  * ```typescript
- * // The callback's return value is returned from touchElement:
- * const inputValue: TheType = touchElement('#my-input', (input: HTMLInputElement): string => input.value)
+ * // -------------------------------------------------------------------------
+ * // Automatically attempts to parse CSS selectors into element types, which
+ * // should work for tag-qualified CSS selectors
+ * // -------------------------------------------------------------------------
  *
- * // and because the query for '#my-input' can fail:
+ * touchElement('input#my-input', (input) => {
+ *     // input is HTMLInputElement
+ * })
+ *
+ * // -------------------------------------------------------------------------
+ * // When using non-recognised selectors the element type defaults to `Element`
+ * // -------------------------------------------------------------------------
+ *
+ * touchElement('#my-input', (input) => {
+ *     // input is Element
+ * })
+ *
+ * // -------------------------------------------------------------------------
+ * // When it fails to infer the element types from given CSS selector you can
+ * // specify the type explicitly
+ * // -------------------------------------------------------------------------
+ *
+ * // Either let the callback specify the element types:
+ * touchElement('#my-input', (input: HTMLElement) => { ... })s
+ *
+ * // or provide the element type as type argument:
+ * touchElement<HTMLElement>('#my-input', (input) => { ... })
+ *
+ * // -------------------------------------------------------------------------
+ * // The callback's return value is returned from touchElement:
+ * // -------------------------------------------------------------------------
+ *
+ * const result: TheType = touchElement('input#my-input', (input) => input.value)
+ *
+ * // and because the query for 'input#my-input' can fail to find an element:
  * type TheType = string | null
  * ```
  */
@@ -25,3 +56,5 @@ export function touchElement(selector: string, callback: (element: Element) => a
     const element = scope.querySelector(selector)
     return element && callback(element)
 }
+
+touchElement('input#my-input', (input) => {})

--- a/src/touchElement.ts
+++ b/src/touchElement.ts
@@ -1,3 +1,5 @@
+import { ParseSelector } from 'typed-query-selector/parser'
+
 /**
  * Finds the first element within the set scope that matches `selector`. If found the element
  * is applied to the given callback function, and the function's return value will be propagated
@@ -17,7 +19,9 @@
  * type TheType = string | null
  * ```
  */
-export function touchElement<T extends Element, U = any>(selector: string, callback: (element: T) => U, scope: ParentNode = document): U | null {
-    const element = scope.querySelector<T>(selector)
+export function touchElement<S extends string, U = any>(selector: S, callback: (element: ParseSelector<S>) => U, scope?: ParentNode): U | null
+export function touchElement<T extends Element, U = any>(selector: string, callback: (element: T) => U, scope?: ParentNode): U | null
+export function touchElement(selector: string, callback: (element: Element) => any, scope: ParentNode = document) {
+    const element = scope.querySelector(selector)
     return element && callback(element)
 }

--- a/src/touchElementP.ts
+++ b/src/touchElementP.ts
@@ -1,3 +1,4 @@
+import { ParseSelector } from 'typed-query-selector/parser'
 import { touchElement } from './touchElement'
 
 /**
@@ -14,6 +15,8 @@ import { touchElement } from './touchElement'
  * const button = await touchElementP<HTMLButtonElement>('#my-button')
  * ```
  */
-export function touchElementP<T extends Element>(selector: string, scope: ParentNode = document): Promise<T> {
-    return new Promise((resolve) => touchElement<T>(selector, resolve, scope))
+export function touchElementP<S extends string>(selector: S, scope?: ParentNode): Promise<ParseSelector<S>>
+export function touchElementP<T extends Element>(selector: string, scope?: ParentNode): Promise<T>
+export function touchElementP(selector: string, scope: ParentNode = document) {
+    return new Promise((resolve) => touchElement(selector, resolve, scope))
 }

--- a/src/touchElementP.ts
+++ b/src/touchElementP.ts
@@ -12,7 +12,28 @@ import { touchElement } from './touchElement'
  *
  * @example
  * ```typescript
- * const button = await touchElementP<HTMLButtonElement>('#my-button')
+ * // -------------------------------------------------------------------------
+ * // Automatically attempts to parse CSS selectors into element types, which
+ * // should work for tag-qualified CSS selectors
+ * // -------------------------------------------------------------------------
+ *
+ * touchElementP('form.my-form button#my-button')
+ * // Promise<HTMLButtonElement>
+ *
+ * // -------------------------------------------------------------------------
+ * // When using non-recognised selectors the element type defaults to `Element`
+ * // -------------------------------------------------------------------------
+ *
+ * touchElementP<HTMLButtonElement>('#my-button')
+ * // Promise<Element>
+ *
+ * // -------------------------------------------------------------------------
+ * // When it fails to infer the element types from given CSS selector you can
+ * // specify the type explicitly
+ * // -------------------------------------------------------------------------
+ *
+ * touchElementP<HTMLButtonElement>('#my-button')
+ * // Promise<HTMLButtonElement>
  * ```
  */
 export function touchElementP<S extends string>(selector: S, scope?: ParentNode): Promise<ParseSelector<S>>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,6 +4333,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+typed-query-selector@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.4.1.tgz#81f74bad05091dcbfbbe96c3fa2e2465771894b4"
+  integrity sha512-X6fx0EywD73wsH/w0X2YMqx9wiW99vIhN9nptTP+uvNB5wk0U3t1zzq50IFgdtxbwFP8Ap3N7k7BL2vmKJf4+g==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -4362,10 +4367,15 @@ typedoc@^0.20.34:
     shiki "^0.9.3"
     typedoc-default-themes "^0.12.9"
 
-typescript@>=3.0.1, typescript@^4.0.5:
+typescript@>=3.0.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+typescript@^4.2:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 uglify-js@^3.1.4:
   version "3.13.3"


### PR DESCRIPTION
Adds type-level CSS selector parsing to all functions that query the DOM with given selectors:
- queryAll()
- queryWithin()
- touchAll()
- touchAllP()
- touchElement()
- touchElementP()